### PR TITLE
Adds reference to ILSpyCMD

### DIFF
--- a/src/content/docs/creating-a-mod/initial-setup.mdx
+++ b/src/content/docs/creating-a-mod/initial-setup.mdx
@@ -79,6 +79,10 @@ You only need one decompiler. Recommended options:
 - [dnSpy](https://github.com/dnSpyEx/dnSpy)
 - [dotPeek](https://www.jetbrains.com/decompiler/#)
 
+Commandline option for advanced users:
+
+- [ILSpyCMD](https://www.nuget.org/packages/ilspycmd/)
+
 You’re now ready to move on:
 
 <LinkCard


### PR DESCRIPTION
Added a link to ILSpyCMD, the dotnet CLI decompiler tool, useful for Linux and headless environments where GUI tools aren’t practical.